### PR TITLE
Pin numpy at <=2.0 to avoid pandas issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     'langchain',
     'langchain_aws',
     'aind-metadata-upgrader>=0.6.2',
+    'numpy<2.0',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In #52, I reported a conflict between the pinned version of Pandas from the data-access-api and the unpinned version of numpy. 

This PR pins numpy at < 2.0 in the pyproject.toml to avoid this conflict.

Closes #52 