### PR TITLE
Add side by side comparison of pre/post upgrade metadata to the upgrade app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     'langchain',
     'langchain_aws',
     'aind-metadata-upgrader>=0.6.2',
+    'numpy<2.0',
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -4,6 +4,7 @@ import pandas as pd
 import panel as pn
 from aind_metadata_upgrader.upgrade import Upgrade
 from aind_metadata_viz.utils import AIND_COLORS, outer_style
+from aind_data_schema import __version__ as schema_version
 import copy
 import json
 import traceback
@@ -277,18 +278,35 @@ def display_upgrade_results(results):
     asset_name = results.get('asset_name', 'Unknown')
     if results['overall_success']:
         status_color = AIND_COLORS['green']
-        status_text = "✓ Full upgrade successful"
+        status_text = "SUCCESS: Full upgrade successful"
     elif results.get('partial_success'):
         status_color = AIND_COLORS['yellow']
-        status_text = "⚠ Partial upgrade (some fields failed)"
+        status_text = "PARTIAL: Some fields failed"
     else:
         status_color = AIND_COLORS['red']
-        status_text = "✗ Upgrade failed"
+        status_text = "FAILED: Upgrade failed"
 
     header_md = f"## Upgrade Results for: {asset_name}\n\n"
     header_md += f"<span style='color:{status_color}; font-weight:bold;'>{status_text}</span>\n\n"
-    header_md += f"<small>Schema upgrade: <code>v1.x</code> → <code>v2.0</code></small>"
+    header_md += f"<small>Schema upgrade: <code>v1.x</code> -> <code>v{schema_version}</code></small>"
     main_col.append(pn.pane.Markdown(header_md))
+
+    # Summary statistics panel
+    files_tested = results.get('files_tested', {})
+    total_files = len(files_tested)
+    successful_files = sum(1 for f in files_tested.values() if f.get('success', False))
+    failed_files = total_files - successful_files
+
+    if total_files > 0:
+        summary_md = f"""
+<div style='background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; padding: 15px; margin: 15px 0;'>
+    <strong>Summary:</strong> {total_files} files tested
+    <br/>
+    <span style='color:{AIND_COLORS['green']}'>{successful_files} successful</span> |
+    <span style='color:{AIND_COLORS['red']}'>{failed_files} failed</span>
+</div>
+"""
+        main_col.append(pn.pane.Markdown(summary_md))
 
     # Overall error message if present
     if results.get('overall_error'):
@@ -301,22 +319,14 @@ def display_upgrade_results(results):
         success = file_result.get('success', False)
         converted_to = file_result.get('converted_to')
 
-        # Determine header color and icon
-        if success:
-            color = AIND_COLORS['green']
-            icon = "✓"
-        else:
-            color = AIND_COLORS['red']
-            icon = "✗"
-
         # Create display name
         display_name = f"{file_name}"
         if converted_to:
-            display_name += f" → {converted_to}"
+            display_name += f" -> {converted_to}"
 
         # Create collapsible section with button
         toggle_button = pn.widgets.Button(
-            name=f"{icon} {display_name}",
+            name=display_name,
             button_type="primary" if success else "danger",
             width=300,
         )
@@ -328,8 +338,8 @@ def display_upgrade_results(results):
         if converted_to:
             notice_md = f"""
 <div style='background-color: {AIND_COLORS['light_blue']}20; border-left: 4px solid {AIND_COLORS['light_blue']}; padding: 10px; margin: 10px 0;'>
-    <strong>🔄 Field Conversion:</strong> <code>{file_name}</code> → <code>{converted_to}</code>
-    <br/><small>This field was renamed in schema v2.0</small>
+    <strong>Field Conversion:</strong> <code>{file_name}</code> -> <code>{converted_to}</code>
+    <br/><small>This field was renamed in schema v{schema_version}</small>
 </div>
 """
             content_col.append(pn.pane.Markdown(notice_md))
@@ -361,7 +371,7 @@ def display_upgrade_results(results):
             error_text = file_result.get('error', 'Unknown error')
             error_md = f"""
 <div style='background-color: {AIND_COLORS['red']}20; border-left: 4px solid {AIND_COLORS['red']}; padding: 10px; margin: 10px 0;'>
-    <strong>❌ Upgrade Failed</strong><br/>
+    <strong>Upgrade Failed</strong><br/>
     {error_text}
 </div>
 """

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -96,30 +96,6 @@ def get_data():
     return df
 
 
-def run_upgrade(record_id_or_name: str):
-    record = None
-    # Try to find by _id first
-    record = client.retrieve_docdb_records(
-        filter_query={"_id": record_id_or_name},
-        limit=1,
-    )
-    if not record:
-        # Try to find by name
-        record = client.retrieve_docdb_records(
-            filter_query={"name": record_id_or_name},
-            limit=1,
-        )
-    if not record:
-        return f"Record with _id or name '{record_id_or_name}' not found."
-
-    record = record[0]
-    try:
-        Upgrade(record)
-        return f"Upgrade successful for record '{record_id_or_name}'."
-    except Exception as e:
-        return f"Upgrade failed for record '{record_id_or_name}': {e}"
-
-
 def upgrade_asset_detailed(record_id_or_name: str):
     """
     Perform detailed upgrade testing with field-by-field breakdown.

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -433,7 +433,18 @@ def build_panel_app():
 
     text_input = pn.widgets.TextInput(name="Enter _id or name", placeholder="Type _id or name here...")
     upgrade_button = pn.widgets.Button(name="Run Upgrade", button_type="success")
+    copy_url_button = pn.widgets.Button(name="Copy Shareable URL", button_type="default", width=180)
+    copy_status = pn.pane.Markdown("", width=150)
     output_box = pn.Column(sizing_mode="stretch_width")
+    js_pane = pn.pane.HTML("", height=0, width=0)
+
+    # Sync text_input with URL parameter
+    pn.state.location.sync(text_input, {"value": "asset_id"})
+
+    # Auto-run upgrade if asset_id is in URL
+    if text_input.value:
+        results = upgrade_asset_detailed(text_input.value)
+        output_box[:] = [display_upgrade_results(results)]
 
     def load_table(event):
         table_col.loading = True
@@ -467,15 +478,40 @@ def build_panel_app():
         # Display results with side-by-side comparison
         output_box[:] = [display_upgrade_results(results)]
 
+    def copy_url_callback(event):
+        # Generate JavaScript to copy current URL to clipboard
+        js_code = """
+var url = window.location.href;
+navigator.clipboard.writeText(url).then(function() {
+    console.log('URL copied to clipboard');
+}, function(err) {
+    console.error('Failed to copy URL: ', err);
+});
+"""
+        js_pane.object = ""
+        js_pane.object = f"<script>{js_code}</script>"
+        copy_status.object = "<span style='color:green'>URL copied!</span>"
+
+        # Clear status after 3 seconds
+        import time
+        def clear_status():
+            time.sleep(3)
+            copy_status.object = ""
+
+        import threading
+        threading.Thread(target=clear_status, daemon=True).start()
+
     button.on_click(load_table)
     upgrade_button.on_click(run_upgrade_callback)
+    copy_url_button.on_click(copy_url_callback)
     table_col.append(button)
     main_col = pn.Column(
         "# Metadata Upgrade Status Table",
         summary_box,
         table_col,
-        pn.Row(text_input, upgrade_button),
+        pn.Row(text_input, upgrade_button, copy_url_button, copy_status),
         output_box,
+        js_pane,
         sizing_mode="stretch_width"
     )
     return main_col

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -96,7 +96,7 @@ def get_data():
     return df
 
 
-def upgrade_asset_detailed(record_id_or_name: str):
+def run_upgrade(record_id_or_name: str):
     """
     Perform detailed upgrade testing with field-by-field breakdown.
 
@@ -287,15 +287,21 @@ def display_upgrade_results(results):
     failed_files = total_files - successful_files
 
     if total_files > 0:
-        summary_md = f"""
-            <div style='background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; padding: 15px; margin: 15px 0;'>
-                <strong>Summary:</strong> {total_files} files tested
-                <br/>
-                <span style='color:{AIND_COLORS['green']}'>{successful_files} successful</span> |
-                <span style='color:{AIND_COLORS['red']}'>{failed_files} failed</span>
-            </div>
-        """
-        main_col.append(pn.pane.Markdown(summary_md))
+        summary_text = f"**Summary:** {total_files} files tested\n\n"
+        summary_text += f"<span style='color:{AIND_COLORS['green']}'>{successful_files} successful</span> | "
+        summary_text += f"<span style='color:{AIND_COLORS['red']}'>{failed_files} failed</span>"
+
+        summary_pane = pn.pane.Markdown(
+            summary_text,
+            styles={
+                "background": "#f8f9fa",
+                "border": "1px solid #dee2e6",
+                "border-radius": "5px",
+                "padding": "15px",
+                "margin": "15px 0",
+            },
+        )
+        main_col.append(summary_pane)
 
     # Overall error message if present
     if results.get("overall_error"):
@@ -327,13 +333,16 @@ def display_upgrade_results(results):
 
         # Add conversion notice if applicable
         if converted_to:
-            notice_md = f"""
-                <div style='background-color: {AIND_COLORS['light_blue']}20; border-left: 4px solid {AIND_COLORS['light_blue']}; padding: 10px; margin: 10px 0;'>
-                    <strong>Field Conversion:</strong> <code>{file_name}</code> -> <code>{converted_to}</code>
-                    <br/><small>This field was renamed in schema v{schema_version}</small>
-                </div>
-            """
-            content_col.append(pn.pane.Markdown(notice_md))
+            notice_pane = pn.pane.Markdown(
+                f"**Field Conversion:** `{file_name}` -> `{converted_to}`\n\nThis field was renamed in schema v{schema_version}",
+                styles={
+                    "background": "#e3f2fd",
+                    "border-left": f"4px solid {AIND_COLORS['light_blue']}",
+                    "padding": "10px",
+                    "margin": "10px 0",
+                },
+            )
+            content_col.append(notice_pane)
 
         if success:
             # Side-by-side comparison
@@ -380,13 +389,16 @@ def display_upgrade_results(results):
         else:
             # Show error
             error_text = file_result.get("error", "Unknown error")
-            error_md = f"""
-                <div style='background-color: {AIND_COLORS['red']}20; border-left: 4px solid {AIND_COLORS['red']}; padding: 10px; margin: 10px 0;'>
-                    <strong>Upgrade Failed</strong><br/>
-                    {error_text}
-                </div>
-            """
-            content_col.append(pn.pane.Markdown(error_md))
+            error_pane = pn.pane.Markdown(
+                f"**Upgrade Failed:**\n\n{error_text}",
+                styles={
+                    "background": "#fff5f5",
+                    "border-left": f"4px solid {AIND_COLORS['red']}",
+                    "padding": "10px",
+                    "margin": "10px 0",
+                },
+            )
+            content_col.append(error_pane)
 
             # Add collapsible traceback if available
             traceback_text = file_result.get("traceback")
@@ -485,7 +497,6 @@ def build_panel_app():
         width=200,
         disabled=True,
     )
-    copy_status = pn.pane.Markdown("", width=150)
     output_box = pn.Column(sizing_mode="stretch_width")
     js_pane = pn.pane.HTML("", height=0, width=0)
 
@@ -495,34 +506,13 @@ def build_panel_app():
 
     text_input.param.watch(update_upgrade_button, "value")
 
-    # Light style for help text box
-    help_box_style = {
-        "background": "#f8f9fa",
-        "border": "1px solid #dee2e6",
-        "border-radius": "5px",
-        "padding": "15px",
-        "margin": "10px 0",
-    }
-
-    help_text = pn.pane.Markdown(
-        """
-        **How it works:** This tool tests metadata upgrades from schema v1.x to v{version}.
-        It first attempts a full upgrade. If that fails, it tests each metadata file individually
-        to identify which specific fields have issues.
-        """.format(
-            version=schema_version
-        ),
-        styles=help_box_style,
-        sizing_mode="stretch_width",
-    )
-
     # Sync text_input with URL parameter
     pn.state.location.sync(text_input, {"value": "asset_id"})
 
     # Auto-run upgrade if asset_id is in URL
     if text_input.value:
         upgrade_button.disabled = False
-        results = upgrade_asset_detailed(text_input.value)
+        results = run_upgrade(text_input.value)
         output_box[:] = [display_upgrade_results(results)]
         copy_url_button.disabled = False
 
@@ -560,11 +550,10 @@ def build_panel_app():
         output_box.loading = True
         upgrade_button.disabled = True
         copy_url_button.disabled = True
-        copy_status.object = ""
 
         try:
             # Use detailed upgrade function
-            results = upgrade_asset_detailed(record_id_or_name)
+            results = run_upgrade(record_id_or_name)
 
             # Display results with side-by-side comparison
             output_box[:] = [display_upgrade_results(results)]
@@ -588,18 +577,6 @@ def build_panel_app():
         """
         js_pane.object = ""
         js_pane.object = f"<script>{js_code}</script>"
-        copy_status.object = "<span style='color:green'>URL copied!</span>"
-
-        # Clear status after 3 seconds
-        import time
-
-        def clear_status():
-            time.sleep(3)
-            copy_status.object = ""
-
-        import threading
-
-        threading.Thread(target=clear_status, daemon=True).start()
 
     button.on_click(load_table)
     upgrade_button.on_click(run_upgrade_callback)
@@ -613,8 +590,6 @@ def build_panel_app():
         upgrade_button,
         pn.Spacer(width=5),
         copy_url_button,
-        pn.Spacer(width=5),
-        copy_status,
         sizing_mode="stretch_width",
         align="center",
     )
@@ -623,7 +598,6 @@ def build_panel_app():
         "# Metadata Upgrade Status Table",
         summary_box,
         table_col,
-        help_text,
         input_label,
         input_row,
         output_box,

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -13,7 +13,7 @@ import traceback
 REDSHIFT_SECRETS = "/aind/prod/redshift/credentials/readonly"
 RDS_TABLE_NAME = "metadata_upgrade_status_prod"
 
-pn.extension('tabulator')
+pn.extension("tabulator")
 
 
 extra_columns = {
@@ -134,24 +134,24 @@ def upgrade_asset_detailed(record_id_or_name: str):
         )
     if not record:
         return {
-            'error': f"Record with _id or name '{record_id_or_name}' not found.",
-            'overall_success': False,
+            "error": f"Record with _id or name '{record_id_or_name}' not found.",
+            "overall_success": False,
         }
 
     record = record[0]
-    asset_name = record.get('name', record.get('_id', 'Unknown'))
+    asset_name = record.get("name", record.get("_id", "Unknown"))
 
     # Deep copy original record for comparison
     original_record = copy.deepcopy(record)
 
     # Initialize results structure
     results = {
-        'overall_success': False,
-        'overall_error': None,
-        'overall_traceback': None,
-        'asset_name': asset_name,
-        'asset_id': record.get('_id'),
-        'files_tested': {},
+        "overall_success": False,
+        "overall_error": None,
+        "overall_traceback": None,
+        "asset_name": asset_name,
+        "asset_id": record.get("_id"),
+        "files_tested": {},
     }
 
     # STEP 1: Try full asset upgrade
@@ -160,7 +160,7 @@ def upgrade_asset_detailed(record_id_or_name: str):
         upgraded_metadata = upgrader.metadata.model_dump()
 
         # Success! Extract per-field data
-        results['overall_success'] = True
+        results["overall_success"] = True
 
         for core_file in CORE_FILES:
             if core_file in original_record and original_record[core_file]:
@@ -168,20 +168,20 @@ def upgrade_asset_detailed(record_id_or_name: str):
                 converted_to = FIELD_CONVERSION_MAP.get(core_file)
                 target_field = converted_to if converted_to else core_file
 
-                results['files_tested'][core_file] = {
-                    'success': True,
-                    'error': None,
-                    'v1_data': original_record[core_file],
-                    'v2_data': upgraded_metadata.get(target_field),
-                    'converted_to': converted_to,
+                results["files_tested"][core_file] = {
+                    "success": True,
+                    "error": None,
+                    "v1_data": original_record[core_file],
+                    "v2_data": upgraded_metadata.get(target_field),
+                    "converted_to": converted_to,
                 }
 
         return results
 
     except Exception as e:
         # Full upgrade failed, capture error
-        results['overall_error'] = str(e)
-        results['overall_traceback'] = traceback.format_exc()
+        results["overall_error"] = str(e)
+        results["overall_traceback"] = traceback.format_exc()
 
     # STEP 2: Field-by-field testing with skip_metadata_validation=True
     for core_file in CORE_FILES:
@@ -196,13 +196,13 @@ def upgrade_asset_detailed(record_id_or_name: str):
         }
 
         # Add subject as companion data if testing other files
-        if core_file != 'subject' and 'subject' in original_record:
-            test_dict['subject'] = copy.deepcopy(original_record['subject'])
+        if core_file != "subject" and "subject" in original_record:
+            test_dict["subject"] = copy.deepcopy(original_record["subject"])
 
         # Add required metadata fields
-        test_dict['_id'] = record.get('_id', 'test')
-        test_dict['name'] = record.get('name', 'test')
-        test_dict['location'] = record.get('location', '')
+        test_dict["_id"] = record.get("_id", "test")
+        test_dict["name"] = record.get("name", "test")
+        test_dict["location"] = record.get("location", "")
 
         try:
             field_upgrader = Upgrade(test_dict, skip_metadata_validation=True)
@@ -210,29 +210,29 @@ def upgrade_asset_detailed(record_id_or_name: str):
 
             target_field = converted_to if converted_to else core_file
 
-            results['files_tested'][core_file] = {
-                'success': True,
-                'error': None,
-                'v1_data': original_record[core_file],
-                'v2_data': field_upgraded.get(target_field),
-                'converted_to': converted_to,
+            results["files_tested"][core_file] = {
+                "success": True,
+                "error": None,
+                "v1_data": original_record[core_file],
+                "v2_data": field_upgraded.get(target_field),
+                "converted_to": converted_to,
             }
 
         except Exception as e:
-            results['files_tested'][core_file] = {
-                'success': False,
-                'error': str(e),
-                'traceback': traceback.format_exc(),
-                'v1_data': original_record[core_file],
-                'v2_data': None,
-                'converted_to': converted_to,
+            results["files_tested"][core_file] = {
+                "success": False,
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+                "v1_data": original_record[core_file],
+                "v2_data": None,
+                "converted_to": converted_to,
             }
 
     # Determine if any fields succeeded
     successful_fields = [
-        f for f, r in results['files_tested'].items() if r['success']
+        f for f, r in results["files_tested"].items() if r["success"]
     ]
-    results['partial_success'] = len(successful_fields) > 0
+    results["partial_success"] = len(successful_fields) > 0
 
     return results
 
@@ -242,10 +242,10 @@ def display_upgrade_results(results):
     Build Panel UI components to display upgrade results with collapsible
     side-by-side JSON comparisons.
     """
-    if 'error' in results and not results.get('overall_success'):
+    if "error" in results and not results.get("overall_success"):
         return pn.pane.Markdown(
             f"**Error:** {results['error']}",
-            styles={'color': AIND_COLORS['red']}
+            styles={"color": AIND_COLORS["red"]},
         )
 
     # Light style for JSON boxes (matching Flask original)
@@ -260,49 +260,55 @@ def display_upgrade_results(results):
     main_col = pn.Column(sizing_mode="stretch_width")
 
     # Overall status header
-    asset_name = results.get('asset_name', 'Unknown')
-    if results['overall_success']:
-        status_color = AIND_COLORS['green']
+    asset_name = results.get("asset_name", "Unknown")
+    if results["overall_success"]:
+        status_color = AIND_COLORS["green"]
         status_text = "SUCCESS: Full upgrade successful"
-    elif results.get('partial_success'):
-        status_color = AIND_COLORS['yellow']
+    elif results.get("partial_success"):
+        status_color = AIND_COLORS["yellow"]
         status_text = "PARTIAL: Some fields failed"
     else:
-        status_color = AIND_COLORS['red']
+        status_color = AIND_COLORS["red"]
         status_text = "FAILED: Upgrade failed"
 
     header_md = f"## Upgrade Results for: {asset_name}\n\n"
     header_md += f"<span style='color:{status_color}; font-weight:bold;'>{status_text}</span>\n"
-    header_md += f"Schema upgrade: <code>v1.x</code> -> <code>v{schema_version}</code>"
+    header_md += (
+        f"Schema upgrade: <code>v1.x</code> -> <code>v{schema_version}</code>"
+    )
     main_col.append(pn.pane.Markdown(header_md))
 
     # Summary statistics panel
-    files_tested = results.get('files_tested', {})
+    files_tested = results.get("files_tested", {})
     total_files = len(files_tested)
-    successful_files = sum(1 for f in files_tested.values() if f.get('success', False))
+    successful_files = sum(
+        1 for f in files_tested.values() if f.get("success", False)
+    )
     failed_files = total_files - successful_files
 
     if total_files > 0:
         summary_md = f"""
-<div style='background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; padding: 15px; margin: 15px 0;'>
-    <strong>Summary:</strong> {total_files} files tested
-    <br/>
-    <span style='color:{AIND_COLORS['green']}'>{successful_files} successful</span> |
-    <span style='color:{AIND_COLORS['red']}'>{failed_files} failed</span>
-</div>
-"""
+            <div style='background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; padding: 15px; margin: 15px 0;'>
+                <strong>Summary:</strong> {total_files} files tested
+                <br/>
+                <span style='color:{AIND_COLORS['green']}'>{successful_files} successful</span> |
+                <span style='color:{AIND_COLORS['red']}'>{failed_files} failed</span>
+            </div>
+        """
         main_col.append(pn.pane.Markdown(summary_md))
 
     # Overall error message if present
-    if results.get('overall_error'):
+    if results.get("overall_error"):
         error_md = f"\n\n**Overall Error:** {results['overall_error']}"
-        main_col.append(pn.pane.Markdown(error_md, styles={'color': AIND_COLORS['red']}))
+        main_col.append(
+            pn.pane.Markdown(error_md, styles={"color": AIND_COLORS["red"]})
+        )
 
     # Process each file
-    files_tested = results.get('files_tested', {})
+    files_tested = results.get("files_tested", {})
     for file_name, file_result in files_tested.items():
-        success = file_result.get('success', False)
-        converted_to = file_result.get('converted_to')
+        success = file_result.get("success", False)
+        converted_to = file_result.get("converted_to")
 
         # Create display name
         display_name = f"{file_name}"
@@ -322,17 +328,17 @@ def display_upgrade_results(results):
         # Add conversion notice if applicable
         if converted_to:
             notice_md = f"""
-<div style='background-color: {AIND_COLORS['light_blue']}20; border-left: 4px solid {AIND_COLORS['light_blue']}; padding: 10px; margin: 10px 0;'>
-    <strong>Field Conversion:</strong> <code>{file_name}</code> -> <code>{converted_to}</code>
-    <br/><small>This field was renamed in schema v{schema_version}</small>
-</div>
-"""
+                <div style='background-color: {AIND_COLORS['light_blue']}20; border-left: 4px solid {AIND_COLORS['light_blue']}; padding: 10px; margin: 10px 0;'>
+                    <strong>Field Conversion:</strong> <code>{file_name}</code> -> <code>{converted_to}</code>
+                    <br/><small>This field was renamed in schema v{schema_version}</small>
+                </div>
+            """
             content_col.append(pn.pane.Markdown(notice_md))
 
         if success:
             # Side-by-side comparison
-            v1_data = file_result.get('v1_data', {})
-            v2_data = file_result.get('v2_data', {})
+            v1_data = file_result.get("v1_data", {})
+            v2_data = file_result.get("v2_data", {})
 
             # Ensure data is JSON serializable
             v1_json = json.loads(json.dumps(v1_data, default=str))
@@ -340,21 +346,31 @@ def display_upgrade_results(results):
 
             # CSS for JSON pane to handle long URLs
             json_pane_styles = {
-                'overflow': 'auto',
-                'word-wrap': 'break-word',
-                'white-space': 'pre-wrap',
+                "overflow": "auto",
+                "word-wrap": "break-word",
+                "white-space": "pre-wrap",
             }
 
             comparison_row = pn.Row(
                 pn.Column(
                     pn.pane.Markdown("### Original (v1)"),
-                    pn.pane.JSON(v1_json, depth=2, styles=json_pane_styles, sizing_mode="stretch_width"),
+                    pn.pane.JSON(
+                        v1_json,
+                        depth=2,
+                        styles=json_pane_styles,
+                        sizing_mode="stretch_width",
+                    ),
                     styles=json_box_style,
                     sizing_mode="stretch_width",
                 ),
                 pn.Column(
                     pn.pane.Markdown("### Upgraded (v2)"),
-                    pn.pane.JSON(v2_json, depth=2, styles=json_pane_styles, sizing_mode="stretch_width"),
+                    pn.pane.JSON(
+                        v2_json,
+                        depth=2,
+                        styles=json_pane_styles,
+                        sizing_mode="stretch_width",
+                    ),
                     styles=json_box_style,
                     sizing_mode="stretch_width",
                 ),
@@ -363,17 +379,17 @@ def display_upgrade_results(results):
             content_col.append(comparison_row)
         else:
             # Show error
-            error_text = file_result.get('error', 'Unknown error')
+            error_text = file_result.get("error", "Unknown error")
             error_md = f"""
-<div style='background-color: {AIND_COLORS['red']}20; border-left: 4px solid {AIND_COLORS['red']}; padding: 10px; margin: 10px 0;'>
-    <strong>Upgrade Failed</strong><br/>
-    {error_text}
-</div>
-"""
+                <div style='background-color: {AIND_COLORS['red']}20; border-left: 4px solid {AIND_COLORS['red']}; padding: 10px; margin: 10px 0;'>
+                    <strong>Upgrade Failed</strong><br/>
+                    {error_text}
+                </div>
+            """
             content_col.append(pn.pane.Markdown(error_md))
 
             # Add collapsible traceback if available
-            traceback_text = file_result.get('traceback')
+            traceback_text = file_result.get("traceback")
             if traceback_text:
                 traceback_button = pn.widgets.Button(
                     name="Show Error Details",
@@ -383,7 +399,7 @@ def display_upgrade_results(results):
                 traceback_col = pn.Column(
                     pn.pane.Markdown(
                         f"```\n{traceback_text}\n```",
-                        styles={'background': '#f5f5f5', 'padding': '10px'}
+                        styles={"background": "#f5f5f5", "padding": "10px"},
                     ),
                     visible=False,
                     sizing_mode="stretch_width",
@@ -392,27 +408,39 @@ def display_upgrade_results(results):
                 def make_traceback_toggle(tb_col, tb_btn):
                     def toggle(event):
                         tb_col.visible = not tb_col.visible
-                        tb_btn.name = "Hide Error Details" if tb_col.visible else "Show Error Details"
+                        tb_btn.name = (
+                            "Hide Error Details"
+                            if tb_col.visible
+                            else "Show Error Details"
+                        )
+
                     return toggle
 
-                traceback_button.on_click(make_traceback_toggle(traceback_col, traceback_button))
+                traceback_button.on_click(
+                    make_traceback_toggle(traceback_col, traceback_button)
+                )
                 content_col.append(traceback_button)
                 content_col.append(traceback_col)
 
             # Show original data
-            v1_data = file_result.get('v1_data', {})
+            v1_data = file_result.get("v1_data", {})
             v1_json = json.loads(json.dumps(v1_data, default=str))
 
             json_pane_styles = {
-                'overflow': 'auto',
-                'word-wrap': 'break-word',
-                'white-space': 'pre-wrap',
+                "overflow": "auto",
+                "word-wrap": "break-word",
+                "white-space": "pre-wrap",
             }
 
             content_col.append(
                 pn.Column(
                     pn.pane.Markdown("### Original Data (v1)"),
-                    pn.pane.JSON(v1_json, depth=2, styles=json_pane_styles, sizing_mode="stretch_width"),
+                    pn.pane.JSON(
+                        v1_json,
+                        depth=2,
+                        styles=json_pane_styles,
+                        sizing_mode="stretch_width",
+                    ),
                     styles=json_box_style,
                     sizing_mode="stretch_width",
                 )
@@ -422,7 +450,10 @@ def display_upgrade_results(results):
         def make_toggle_callback(content):
             def toggle(event):
                 content.visible = not content.visible
-                event.obj.button_type = "primary" if content.visible else "default"
+                event.obj.button_type = (
+                    "primary" if content.visible else "default"
+                )
+
             return toggle
 
         toggle_button.on_click(make_toggle_callback(content_col))
@@ -439,9 +470,21 @@ def build_panel_app():
 
     summary_box = pn.pane.Markdown("", sizing_mode="stretch_width")
 
-    text_input = pn.widgets.TextInput(name="", placeholder="Type _id or name here...", sizing_mode="stretch_width", min_width=300)
-    upgrade_button = pn.widgets.Button(name="Run Upgrade", button_type="success", width=130, disabled=True)
-    copy_url_button = pn.widgets.Button(name="Copy Shareable URL", button_type="default", width=200, disabled=True)
+    text_input = pn.widgets.TextInput(
+        name="",
+        placeholder="Type _id or name here...",
+        sizing_mode="stretch_width",
+        min_width=300,
+    )
+    upgrade_button = pn.widgets.Button(
+        name="Run Upgrade", button_type="success", width=130, disabled=True
+    )
+    copy_url_button = pn.widgets.Button(
+        name="Copy Shareable URL",
+        button_type="default",
+        width=200,
+        disabled=True,
+    )
     copy_status = pn.pane.Markdown("", width=150)
     output_box = pn.Column(sizing_mode="stretch_width")
     js_pane = pn.pane.HTML("", height=0, width=0)
@@ -450,7 +493,7 @@ def build_panel_app():
     def update_upgrade_button(event):
         upgrade_button.disabled = not bool(text_input.value.strip())
 
-    text_input.param.watch(update_upgrade_button, 'value')
+    text_input.param.watch(update_upgrade_button, "value")
 
     # Light style for help text box
     help_box_style = {
@@ -461,11 +504,17 @@ def build_panel_app():
         "margin": "10px 0",
     }
 
-    help_text = pn.pane.Markdown("""
-**How it works:** This tool tests metadata upgrades from schema v1.x to v{version}.
-It first attempts a full upgrade. If that fails, it tests each metadata file individually
-to identify which specific fields have issues.
-""".format(version=schema_version), styles=help_box_style, sizing_mode="stretch_width")
+    help_text = pn.pane.Markdown(
+        """
+        **How it works:** This tool tests metadata upgrades from schema v1.x to v{version}.
+        It first attempts a full upgrade. If that fails, it tests each metadata file individually
+        to identify which specific fields have issues.
+        """.format(
+            version=schema_version
+        ),
+        styles=help_box_style,
+        sizing_mode="stretch_width",
+    )
 
     # Sync text_input with URL parameter
     pn.state.location.sync(text_input, {"value": "asset_id"})
@@ -482,8 +531,8 @@ to identify which specific fields have issues.
         df = get_data()
 
         summary_box.object = f"""
-**Records upgraded:** {len(df[df['status'] == "success"])}/{len(df)}
-"""
+            **Records upgraded:** {len(df[df['status'] == "success"])}/{len(df)}
+        """
 
         tab = pn.widgets.Tabulator(
             df,
@@ -500,7 +549,11 @@ to identify which specific fields have issues.
     def run_upgrade_callback(event):
         record_id_or_name = text_input.value
         if not record_id_or_name:
-            output_box[:] = [pn.pane.Markdown("**Error:** Please enter an asset ID or name.")]
+            output_box[:] = [
+                pn.pane.Markdown(
+                    "**Error:** Please enter an asset ID or name."
+                )
+            ]
             return
 
         # Show loading state
@@ -526,24 +579,26 @@ to identify which specific fields have issues.
     def copy_url_callback(event):
         # Generate JavaScript to copy current URL to clipboard
         js_code = """
-var url = window.location.href;
-navigator.clipboard.writeText(url).then(function() {
-    console.log('URL copied to clipboard');
-}, function(err) {
-    console.error('Failed to copy URL: ', err);
-});
-"""
+            var url = window.location.href;
+            navigator.clipboard.writeText(url).then(function() {
+                console.log('URL copied to clipboard');
+            }, function(err) {
+                console.error('Failed to copy URL: ', err);
+            });
+        """
         js_pane.object = ""
         js_pane.object = f"<script>{js_code}</script>"
         copy_status.object = "<span style='color:green'>URL copied!</span>"
 
         # Clear status after 3 seconds
         import time
+
         def clear_status():
             time.sleep(3)
             copy_status.object = ""
 
         import threading
+
         threading.Thread(target=clear_status, daemon=True).start()
 
     button.on_click(load_table)
@@ -561,7 +616,7 @@ navigator.clipboard.writeText(url).then(function() {
         pn.Spacer(width=5),
         copy_status,
         sizing_mode="stretch_width",
-        align="center"
+        align="center",
     )
 
     main_col = pn.Column(
@@ -573,7 +628,7 @@ navigator.clipboard.writeText(url).then(function() {
         input_row,
         output_box,
         js_pane,
-        sizing_mode="stretch_width"
+        sizing_mode="stretch_width",
     )
     return main_col
 

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -272,6 +272,15 @@ def display_upgrade_results(results):
             styles={'color': AIND_COLORS['red']}
         )
 
+    # Light style for JSON boxes (matching Flask original)
+    json_box_style = {
+        "background": "#f8f9fa",
+        "border": "1px solid #dee2e6",
+        "border-radius": "5px",
+        "padding": "15px",
+        "margin": "5px",
+    }
+
     main_col = pn.Column(sizing_mode="stretch_width")
 
     # Overall status header
@@ -287,8 +296,8 @@ def display_upgrade_results(results):
         status_text = "FAILED: Upgrade failed"
 
     header_md = f"## Upgrade Results for: {asset_name}\n\n"
-    header_md += f"<span style='color:{status_color}; font-weight:bold;'>{status_text}</span>\n\n"
-    header_md += f"<small>Schema upgrade: <code>v1.x</code> -> <code>v{schema_version}</code></small>"
+    header_md += f"<span style='color:{status_color}; font-weight:bold;'>{status_text}</span>\n"
+    header_md += f"Schema upgrade: <code>v1.x</code> -> <code>v{schema_version}</code>"
     main_col.append(pn.pane.Markdown(header_md))
 
     # Summary statistics panel
@@ -328,11 +337,11 @@ def display_upgrade_results(results):
         toggle_button = pn.widgets.Button(
             name=display_name,
             button_type="primary" if success else "danger",
-            width=300,
+            sizing_mode="stretch_width",
         )
 
         # Create content section (initially visible)
-        content_col = pn.Column(styles=outer_style, width=800, visible=True)
+        content_col = pn.Column(sizing_mode="stretch_width", visible=True)
 
         # Add conversion notice if applicable
         if converted_to:
@@ -353,17 +362,27 @@ def display_upgrade_results(results):
             v1_json = json.loads(json.dumps(v1_data, default=str))
             v2_json = json.loads(json.dumps(v2_data, default=str))
 
+            # CSS for JSON pane to handle long URLs
+            json_pane_styles = {
+                'overflow': 'auto',
+                'word-wrap': 'break-word',
+                'white-space': 'pre-wrap',
+            }
+
             comparison_row = pn.Row(
                 pn.Column(
                     pn.pane.Markdown("### Original (v1)"),
-                    pn.pane.JSON(v1_json, depth=2, width=380),
-                    width=400,
+                    pn.pane.JSON(v1_json, depth=2, styles=json_pane_styles, sizing_mode="stretch_width"),
+                    styles=json_box_style,
+                    sizing_mode="stretch_width",
                 ),
                 pn.Column(
                     pn.pane.Markdown("### Upgraded (v2)"),
-                    pn.pane.JSON(v2_json, depth=2, width=380),
-                    width=400,
+                    pn.pane.JSON(v2_json, depth=2, styles=json_pane_styles, sizing_mode="stretch_width"),
+                    styles=json_box_style,
+                    sizing_mode="stretch_width",
                 ),
+                sizing_mode="stretch_width",
             )
             content_col.append(comparison_row)
         else:
@@ -391,7 +410,7 @@ def display_upgrade_results(results):
                         styles={'background': '#f5f5f5', 'padding': '10px'}
                     ),
                     visible=False,
-                    width=780,
+                    sizing_mode="stretch_width",
                 )
 
                 def make_traceback_toggle(tb_col, tb_btn):
@@ -407,8 +426,21 @@ def display_upgrade_results(results):
             # Show original data
             v1_data = file_result.get('v1_data', {})
             v1_json = json.loads(json.dumps(v1_data, default=str))
-            content_col.append(pn.pane.Markdown("### Original Data (v1)"))
-            content_col.append(pn.pane.JSON(v1_json, depth=2, width=780))
+
+            json_pane_styles = {
+                'overflow': 'auto',
+                'word-wrap': 'break-word',
+                'white-space': 'pre-wrap',
+            }
+
+            content_col.append(
+                pn.Column(
+                    pn.pane.Markdown("### Original Data (v1)"),
+                    pn.pane.JSON(v1_json, depth=2, styles=json_pane_styles, sizing_mode="stretch_width"),
+                    styles=json_box_style,
+                    sizing_mode="stretch_width",
+                )
+            )
 
         # Toggle visibility callback
         def make_toggle_callback(content):
@@ -431,20 +463,43 @@ def build_panel_app():
 
     summary_box = pn.pane.Markdown("", sizing_mode="stretch_width")
 
-    text_input = pn.widgets.TextInput(name="Enter _id or name", placeholder="Type _id or name here...")
-    upgrade_button = pn.widgets.Button(name="Run Upgrade", button_type="success")
-    copy_url_button = pn.widgets.Button(name="Copy Shareable URL", button_type="default", width=180)
+    text_input = pn.widgets.TextInput(name="", placeholder="Type _id or name here...", sizing_mode="stretch_width", min_width=300)
+    upgrade_button = pn.widgets.Button(name="Run Upgrade", button_type="success", width=130, disabled=True)
+    copy_url_button = pn.widgets.Button(name="Copy Shareable URL", button_type="default", width=200, disabled=True)
     copy_status = pn.pane.Markdown("", width=150)
     output_box = pn.Column(sizing_mode="stretch_width")
     js_pane = pn.pane.HTML("", height=0, width=0)
+
+    # Enable/disable upgrade button based on text input
+    def update_upgrade_button(event):
+        upgrade_button.disabled = not bool(text_input.value.strip())
+
+    text_input.param.watch(update_upgrade_button, 'value')
+
+    # Light style for help text box
+    help_box_style = {
+        "background": "#f8f9fa",
+        "border": "1px solid #dee2e6",
+        "border-radius": "5px",
+        "padding": "15px",
+        "margin": "10px 0",
+    }
+
+    help_text = pn.pane.Markdown("""
+**How it works:** This tool tests metadata upgrades from schema v1.x to v{version}.
+It first attempts a full upgrade. If that fails, it tests each metadata file individually
+to identify which specific fields have issues.
+""".format(version=schema_version), styles=help_box_style, sizing_mode="stretch_width")
 
     # Sync text_input with URL parameter
     pn.state.location.sync(text_input, {"value": "asset_id"})
 
     # Auto-run upgrade if asset_id is in URL
     if text_input.value:
+        upgrade_button.disabled = False
         results = upgrade_asset_detailed(text_input.value)
         output_box[:] = [display_upgrade_results(results)]
+        copy_url_button.disabled = False
 
     def load_table(event):
         table_col.loading = True
@@ -472,11 +527,25 @@ def build_panel_app():
             output_box[:] = [pn.pane.Markdown("**Error:** Please enter an asset ID or name.")]
             return
 
-        # Use detailed upgrade function
-        results = upgrade_asset_detailed(record_id_or_name)
+        # Show loading state
+        output_box.loading = True
+        upgrade_button.disabled = True
+        copy_url_button.disabled = True
+        copy_status.object = ""
 
-        # Display results with side-by-side comparison
-        output_box[:] = [display_upgrade_results(results)]
+        try:
+            # Use detailed upgrade function
+            results = upgrade_asset_detailed(record_id_or_name)
+
+            # Display results with side-by-side comparison
+            output_box[:] = [display_upgrade_results(results)]
+
+            # Enable copy URL button after successful upgrade
+            copy_url_button.disabled = False
+        finally:
+            # Clear loading state
+            output_box.loading = False
+            upgrade_button.disabled = False
 
     def copy_url_callback(event):
         # Generate JavaScript to copy current URL to clipboard
@@ -505,11 +574,27 @@ navigator.clipboard.writeText(url).then(function() {
     upgrade_button.on_click(run_upgrade_callback)
     copy_url_button.on_click(copy_url_callback)
     table_col.append(button)
+    input_label = pn.pane.Markdown("**Enter _id or name:**")
+
+    input_row = pn.Row(
+        text_input,
+        pn.Spacer(width=5),
+        upgrade_button,
+        pn.Spacer(width=5),
+        copy_url_button,
+        pn.Spacer(width=5),
+        copy_status,
+        sizing_mode="stretch_width",
+        align="center"
+    )
+
     main_col = pn.Column(
         "# Metadata Upgrade Status Table",
         summary_box,
         table_col,
-        pn.Row(text_input, upgrade_button, copy_url_button, copy_status),
+        help_text,
+        input_label,
+        input_row,
         output_box,
         js_pane,
         sizing_mode="stretch_width"

--- a/src/aind_metadata_viz/upgrade.py
+++ b/src/aind_metadata_viz/upgrade.py
@@ -3,6 +3,10 @@ from aind_data_access_api.document_db import MetadataDbClient
 import pandas as pd
 import panel as pn
 from aind_metadata_upgrader.upgrade import Upgrade
+from aind_metadata_viz.utils import AIND_COLORS, outer_style
+import copy
+import json
+import traceback
 
 # Redshift settings
 REDSHIFT_SECRETS = "/aind/prod/redshift/credentials/readonly"
@@ -115,6 +119,302 @@ def run_upgrade(record_id_or_name: str):
         return f"Upgrade failed for record '{record_id_or_name}': {e}"
 
 
+def upgrade_asset_detailed(record_id_or_name: str):
+    """
+    Perform detailed upgrade testing with field-by-field breakdown.
+
+    Two-step process:
+    1. Try full asset upgrade
+    2. If fails, test each field individually with skip_metadata_validation=True
+
+    Returns dict with detailed results for each field.
+    """
+    # Core files to test, with field conversion mapping
+    FIELD_CONVERSION_MAP = {
+        "session": "acquisition",
+        "rig": "instrument",
+    }
+
+    CORE_FILES = [
+        "data_description",
+        "procedures",
+        "subject",
+        "session",
+        "rig",
+        "processing",
+        "quality_control",
+    ]
+
+    # Retrieve record
+    record = client.retrieve_docdb_records(
+        filter_query={"_id": record_id_or_name},
+        limit=1,
+    )
+    if not record:
+        record = client.retrieve_docdb_records(
+            filter_query={"name": record_id_or_name},
+            limit=1,
+        )
+    if not record:
+        return {
+            'error': f"Record with _id or name '{record_id_or_name}' not found.",
+            'overall_success': False,
+        }
+
+    record = record[0]
+    asset_name = record.get('name', record.get('_id', 'Unknown'))
+
+    # Deep copy original record for comparison
+    original_record = copy.deepcopy(record)
+
+    # Initialize results structure
+    results = {
+        'overall_success': False,
+        'overall_error': None,
+        'overall_traceback': None,
+        'asset_name': asset_name,
+        'asset_id': record.get('_id'),
+        'files_tested': {},
+    }
+
+    # STEP 1: Try full asset upgrade
+    try:
+        upgrader = Upgrade(copy.deepcopy(record))
+        upgraded_metadata = upgrader.metadata.model_dump()
+
+        # Success! Extract per-field data
+        results['overall_success'] = True
+
+        for core_file in CORE_FILES:
+            if core_file in original_record and original_record[core_file]:
+                # Handle field conversion
+                converted_to = FIELD_CONVERSION_MAP.get(core_file)
+                target_field = converted_to if converted_to else core_file
+
+                results['files_tested'][core_file] = {
+                    'success': True,
+                    'error': None,
+                    'v1_data': original_record[core_file],
+                    'v2_data': upgraded_metadata.get(target_field),
+                    'converted_to': converted_to,
+                }
+
+        return results
+
+    except Exception as e:
+        # Full upgrade failed, capture error
+        results['overall_error'] = str(e)
+        results['overall_traceback'] = traceback.format_exc()
+
+    # STEP 2: Field-by-field testing with skip_metadata_validation=True
+    for core_file in CORE_FILES:
+        if core_file not in original_record or not original_record[core_file]:
+            continue  # Skip files not present in record
+
+        converted_to = FIELD_CONVERSION_MAP.get(core_file)
+
+        # Create minimal test dict with just this field + subject
+        test_dict = {
+            core_file: copy.deepcopy(original_record[core_file]),
+        }
+
+        # Add subject as companion data if testing other files
+        if core_file != 'subject' and 'subject' in original_record:
+            test_dict['subject'] = copy.deepcopy(original_record['subject'])
+
+        # Add required metadata fields
+        test_dict['_id'] = record.get('_id', 'test')
+        test_dict['name'] = record.get('name', 'test')
+        test_dict['location'] = record.get('location', '')
+
+        try:
+            field_upgrader = Upgrade(test_dict, skip_metadata_validation=True)
+            field_upgraded = field_upgrader.metadata.model_dump()
+
+            target_field = converted_to if converted_to else core_file
+
+            results['files_tested'][core_file] = {
+                'success': True,
+                'error': None,
+                'v1_data': original_record[core_file],
+                'v2_data': field_upgraded.get(target_field),
+                'converted_to': converted_to,
+            }
+
+        except Exception as e:
+            results['files_tested'][core_file] = {
+                'success': False,
+                'error': str(e),
+                'traceback': traceback.format_exc(),
+                'v1_data': original_record[core_file],
+                'v2_data': None,
+                'converted_to': converted_to,
+            }
+
+    # Determine if any fields succeeded
+    successful_fields = [
+        f for f, r in results['files_tested'].items() if r['success']
+    ]
+    results['partial_success'] = len(successful_fields) > 0
+
+    return results
+
+
+def display_upgrade_results(results):
+    """
+    Build Panel UI components to display upgrade results with collapsible
+    side-by-side JSON comparisons.
+    """
+    if 'error' in results and not results.get('overall_success'):
+        return pn.pane.Markdown(
+            f"**Error:** {results['error']}",
+            styles={'color': AIND_COLORS['red']}
+        )
+
+    main_col = pn.Column(sizing_mode="stretch_width")
+
+    # Overall status header
+    asset_name = results.get('asset_name', 'Unknown')
+    if results['overall_success']:
+        status_color = AIND_COLORS['green']
+        status_text = "✓ Full upgrade successful"
+    elif results.get('partial_success'):
+        status_color = AIND_COLORS['yellow']
+        status_text = "⚠ Partial upgrade (some fields failed)"
+    else:
+        status_color = AIND_COLORS['red']
+        status_text = "✗ Upgrade failed"
+
+    header_md = f"## Upgrade Results for: {asset_name}\n\n"
+    header_md += f"<span style='color:{status_color}; font-weight:bold;'>{status_text}</span>\n\n"
+    header_md += f"<small>Schema upgrade: <code>v1.x</code> → <code>v2.0</code></small>"
+    main_col.append(pn.pane.Markdown(header_md))
+
+    # Overall error message if present
+    if results.get('overall_error'):
+        error_md = f"\n\n**Overall Error:** {results['overall_error']}"
+        main_col.append(pn.pane.Markdown(error_md, styles={'color': AIND_COLORS['red']}))
+
+    # Process each file
+    files_tested = results.get('files_tested', {})
+    for file_name, file_result in files_tested.items():
+        success = file_result.get('success', False)
+        converted_to = file_result.get('converted_to')
+
+        # Determine header color and icon
+        if success:
+            color = AIND_COLORS['green']
+            icon = "✓"
+        else:
+            color = AIND_COLORS['red']
+            icon = "✗"
+
+        # Create display name
+        display_name = f"{file_name}"
+        if converted_to:
+            display_name += f" → {converted_to}"
+
+        # Create collapsible section with button
+        toggle_button = pn.widgets.Button(
+            name=f"{icon} {display_name}",
+            button_type="primary" if success else "danger",
+            width=300,
+        )
+
+        # Create content section (initially visible)
+        content_col = pn.Column(styles=outer_style, width=800, visible=True)
+
+        # Add conversion notice if applicable
+        if converted_to:
+            notice_md = f"""
+<div style='background-color: {AIND_COLORS['light_blue']}20; border-left: 4px solid {AIND_COLORS['light_blue']}; padding: 10px; margin: 10px 0;'>
+    <strong>🔄 Field Conversion:</strong> <code>{file_name}</code> → <code>{converted_to}</code>
+    <br/><small>This field was renamed in schema v2.0</small>
+</div>
+"""
+            content_col.append(pn.pane.Markdown(notice_md))
+
+        if success:
+            # Side-by-side comparison
+            v1_data = file_result.get('v1_data', {})
+            v2_data = file_result.get('v2_data', {})
+
+            # Ensure data is JSON serializable
+            v1_json = json.loads(json.dumps(v1_data, default=str))
+            v2_json = json.loads(json.dumps(v2_data, default=str))
+
+            comparison_row = pn.Row(
+                pn.Column(
+                    pn.pane.Markdown("### Original (v1)"),
+                    pn.pane.JSON(v1_json, depth=2, width=380),
+                    width=400,
+                ),
+                pn.Column(
+                    pn.pane.Markdown("### Upgraded (v2)"),
+                    pn.pane.JSON(v2_json, depth=2, width=380),
+                    width=400,
+                ),
+            )
+            content_col.append(comparison_row)
+        else:
+            # Show error
+            error_text = file_result.get('error', 'Unknown error')
+            error_md = f"""
+<div style='background-color: {AIND_COLORS['red']}20; border-left: 4px solid {AIND_COLORS['red']}; padding: 10px; margin: 10px 0;'>
+    <strong>❌ Upgrade Failed</strong><br/>
+    {error_text}
+</div>
+"""
+            content_col.append(pn.pane.Markdown(error_md))
+
+            # Add collapsible traceback if available
+            traceback_text = file_result.get('traceback')
+            if traceback_text:
+                traceback_button = pn.widgets.Button(
+                    name="Show Error Details",
+                    button_type="warning",
+                    width=200,
+                )
+                traceback_col = pn.Column(
+                    pn.pane.Markdown(
+                        f"```\n{traceback_text}\n```",
+                        styles={'background': '#f5f5f5', 'padding': '10px'}
+                    ),
+                    visible=False,
+                    width=780,
+                )
+
+                def make_traceback_toggle(tb_col, tb_btn):
+                    def toggle(event):
+                        tb_col.visible = not tb_col.visible
+                        tb_btn.name = "Hide Error Details" if tb_col.visible else "Show Error Details"
+                    return toggle
+
+                traceback_button.on_click(make_traceback_toggle(traceback_col, traceback_button))
+                content_col.append(traceback_button)
+                content_col.append(traceback_col)
+
+            # Show original data
+            v1_data = file_result.get('v1_data', {})
+            v1_json = json.loads(json.dumps(v1_data, default=str))
+            content_col.append(pn.pane.Markdown("### Original Data (v1)"))
+            content_col.append(pn.pane.JSON(v1_json, depth=2, width=780))
+
+        # Toggle visibility callback
+        def make_toggle_callback(content):
+            def toggle(event):
+                content.visible = not content.visible
+                event.obj.button_type = "primary" if content.visible else "default"
+            return toggle
+
+        toggle_button.on_click(make_toggle_callback(content_col))
+
+        main_col.append(toggle_button)
+        main_col.append(content_col)
+
+    return main_col
+
+
 def build_panel_app():
     table_col = pn.Column()
     button = pn.widgets.Button(name="Load Table", button_type="primary")
@@ -123,7 +423,7 @@ def build_panel_app():
 
     text_input = pn.widgets.TextInput(name="Enter _id or name", placeholder="Type _id or name here...")
     upgrade_button = pn.widgets.Button(name="Run Upgrade", button_type="success")
-    output_box = pn.pane.Markdown("", sizing_mode="stretch_width")
+    output_box = pn.Column(sizing_mode="stretch_width")
 
     def load_table(event):
         table_col.loading = True
@@ -147,8 +447,15 @@ def build_panel_app():
 
     def run_upgrade_callback(event):
         record_id_or_name = text_input.value
-        result = run_upgrade(record_id_or_name)
-        output_box.object = f"**Upgrade Output:**\n{result}"
+        if not record_id_or_name:
+            output_box[:] = [pn.pane.Markdown("**Error:** Please enter an asset ID or name.")]
+            return
+
+        # Use detailed upgrade function
+        results = upgrade_asset_detailed(record_id_or_name)
+
+        # Display results with side-by-side comparison
+        output_box[:] = [display_upgrade_results(results)]
 
     button.on_click(load_table)
     upgrade_button.on_click(run_upgrade_callback)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -47,44 +47,43 @@ rds = [
 
 [[package]]
 name = "aind-data-schema"
-version = "2.2.0"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aind-data-schema-models" },
     { name = "pydantic" },
-    { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1e/9e17fb42209ce92a95c4b3e5cafc399fc742255261fc21ddcc3195083d66/aind_data_schema-2.2.0.tar.gz", hash = "sha256:26e749d9b227378cd001dc4b1eff0f1cd0c626147484ddf89cdf18ed7c0c110c", size = 865576, upload-time = "2025-11-25T22:34:47.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/71f38df69f02e942d098f9310982082aac334de5c496bd3fc605bcd3b431/aind_data_schema-2.4.0.tar.gz", hash = "sha256:a239e38591113f445ca316bc4386c466718e8715a92d8bdbca891a82b9d7ff16", size = 873259, upload-time = "2026-01-06T18:00:34.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/e5/904b07d0d0dbac1900026d7cc53d63f280abe495f856c2d5251706c0ff21/aind_data_schema-2.2.0-py3-none-any.whl", hash = "sha256:1416a3c527651078a93251160cfe7d6a0b5cc6f52dbbdc799b19b378f1243138", size = 87890, upload-time = "2025-11-25T22:34:46.171Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/9632026c77aa8c512e8e15ddec8c9fbfcf6ae272c0c28997e5f12f7a9433/aind_data_schema-2.4.0-py3-none-any.whl", hash = "sha256:1e8284b1e88928e77598ecae70025a2a5ca62b2cded594f62abf8a0aa17d8b34", size = 89429, upload-time = "2026-01-06T18:00:32.616Z" },
 ]
 
 [[package]]
 name = "aind-data-schema-models"
-version = "4.6.1"
+version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-resources" },
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/e1/e35ce9a4ae4c444c9eddc0b3e954772b2e26dfbecf56224a2e84249b6e9a/aind_data_schema_models-4.6.1.tar.gz", hash = "sha256:be088babb26b02c8c21af74a817128372dd8f336471dbce9d78b9ae1aba8328f", size = 338317, upload-time = "2025-12-03T23:52:15.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/e7/b1c40e19bd3267e9c1d1099fb98c4b0d211bc25061fbedc8caafebc48399/aind_data_schema_models-5.2.2.tar.gz", hash = "sha256:962b1ecc52e38ea29fad9f126ff52c7fdb3296d7f23ef774f33987d2ccf61d06", size = 340495, upload-time = "2026-01-22T18:57:03.242Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/96/0921530ae2ef435d2a42cbb32e4f2114e7562a2d30a791438f127b2e47b9/aind_data_schema_models-4.6.1-py3-none-any.whl", hash = "sha256:dfecb09b80fdb12b980309ebf591caa9a8b71f53e6ef564345d44be3d4a0dcd2", size = 307107, upload-time = "2025-12-03T23:52:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2a/e3cb794c232e1b599bada18e383d2a29c74069d36f84408c5598f27c3253/aind_data_schema_models-5.2.2-py3-none-any.whl", hash = "sha256:271db7fd193392c811fd705da58950bc81357a7b2bc68dd1fe9eda53ce057d6a", size = 309917, upload-time = "2026-01-22T18:57:01.65Z" },
 ]
 
 [[package]]
 name = "aind-metadata-upgrader"
-version = "0.3.5"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aind-data-access-api", extra = ["docdb"] },
     { name = "aind-data-schema" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/64/83058c47e9b15f8633cd13321d017b0e9f21b8a93f57734224c6a16f7fc0/aind_metadata_upgrader-0.3.5.tar.gz", hash = "sha256:084d332f96a66a138bdf0a55bb2c2c7be12de61d242844503a2a80cf4df65542", size = 4927268, upload-time = "2025-11-25T00:01:05.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/51/c20144cfaad9cc736b349988fe51e13ff2e2d1f260bbc48d04e73709e3fd/aind_metadata_upgrader-0.6.2.tar.gz", hash = "sha256:44b4ca3c85bfa3b5326dd56bedc79249fa7a5b191d6a8709380da9baf1358538", size = 5066764, upload-time = "2026-01-28T23:07:16.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/f0/92e74d650ce5c60760ace27490b52e8884aa9223212a93fcc33b1e0c3b5c/aind_metadata_upgrader-0.3.5-py3-none-any.whl", hash = "sha256:b3d7031c4f9ab19c4643648b8e3e46e6fb080b5b68378d48c3d657bea8501c50", size = 74943, upload-time = "2025-11-25T00:01:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0a/eafc8b65976febc5e104375ed6f3869b89eee1f8dbf5f1f888dde7789af7/aind_metadata_upgrader-0.6.2-py3-none-any.whl", hash = "sha256:26edad3488aa8b3a0a55b8cc2fb6778d2b642d6f13e79f091188faa8eb5fbb80", size = 76454, upload-time = "2026-01-28T23:07:14.085Z" },
 ]
 
 [[package]]
@@ -112,8 +111,11 @@ dependencies = [
     { name = "aind-metadata-validator" },
     { name = "altair" },
     { name = "flask" },
-    { name = "langchain" },
-    { name = "langchain-aws" },
+    { name = "langchain", version = "0.3.27", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "langchain", version = "1.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "langchain-aws", version = "0.2.35", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "langchain-aws", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
     { name = "panel" },
     { name = "pydantic" },
 ]
@@ -136,7 +138,7 @@ requires-dist = [
     { name = "aind-data-access-api", extras = ["docdb"] },
     { name = "aind-data-access-api", extras = ["rds"] },
     { name = "aind-data-schema", specifier = ">=2.2.0" },
-    { name = "aind-metadata-upgrader", specifier = ">=0.3.0" },
+    { name = "aind-metadata-upgrader", specifier = ">=0.6.2" },
     { name = "aind-metadata-validator", specifier = ">=0.11.1" },
     { name = "altair" },
     { name = "black", marker = "extra == 'dev'" },
@@ -148,6 +150,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'" },
     { name = "langchain" },
     { name = "langchain-aws" },
+    { name = "numpy", specifier = "<2.0" },
     { name = "panel", specifier = ">=1.8.2" },
     { name = "pydantic", specifier = "<=2.11.0" },
     { name = "sphinx", marker = "extra == 'dev'" },
@@ -373,8 +376,7 @@ dependencies = [
     { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jinja2" },
     { name = "narwhals" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "pillow" },
@@ -624,7 +626,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -695,7 +697,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1248,12 +1250,37 @@ wheels = [
 
 [[package]]
 name = "langchain"
+version = "0.3.27"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "langchain-core", version = "0.3.83", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "langchain-text-splitters", marker = "python_full_version >= '3.12'" },
+    { name = "langsmith", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "sqlalchemy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/f6/f4f7f3a56626fe07e2bb330feb61254dbdf06c506e6b59a536a337da51cf/langchain-0.3.27.tar.gz", hash = "sha256:aa6f1e6274ff055d0fd36254176770f356ed0a8994297d1df47df341953cec62", size = 10233809, upload-time = "2025-07-24T14:42:32.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/d5/4861816a95b2f6993f1360cfb605aacb015506ee2090433a71de9cca8477/langchain-0.3.27-py3-none-any.whl", hash = "sha256:7b20c4f338826acb148d885b20a73a16e410ede9ee4f19bb02011852d5f98798", size = 1018194, upload-time = "2025-07-24T14:42:30.23Z" },
+]
+
+[[package]]
+name = "langchain"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "langchain-core" },
-    { name = "langgraph" },
-    { name = "pydantic" },
+    { name = "langchain-core", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "langgraph", marker = "python_full_version < '3.12'" },
+    { name = "pydantic", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/7c/127a4b15434bed166c1d81ff3ae7c86d19d41c27ca92b42fbbed0c9bb2a3/langchain-1.1.2.tar.gz", hash = "sha256:5d59557cf9939ff6db60c09bbfca80742865c511ddc33b24fc27920b2bb6157b", size = 530827, upload-time = "2025-12-04T17:59:46.419Z" }
 wheels = [
@@ -1262,14 +1289,35 @@ wheels = [
 
 [[package]]
 name = "langchain-aws"
+version = "0.2.35"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "boto3", marker = "python_full_version >= '3.12'" },
+    { name = "langchain-core", version = "0.3.83", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7a/19a903725acbb1c4481dc0391b2551250bf4e04cbe5a891a55e09319772b/langchain_aws-0.2.35.tar.gz", hash = "sha256:45793a34fe45d365f4292cc768db74669ca24601d2c5da1ac6f44403750d70af", size = 120567, upload-time = "2025-10-02T23:59:57.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/92/1827652b4ed6d8ffaffe8b40be49a6889a9b3cb4b523fb56871691c48601/langchain_aws-0.2.35-py3-none-any.whl", hash = "sha256:8ddb10f3c29f6d52bcbaa4d7f4f56462acf01f608adc7c70f41e5a476899a6bc", size = 145620, upload-time = "2025-10-02T23:59:55.288Z" },
+]
+
+[[package]]
+name = "langchain-aws"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "boto3" },
-    { name = "langchain-core" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic" },
+    { name = "boto3", marker = "python_full_version < '3.12'" },
+    { name = "langchain-core", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "pydantic", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/1d/bb306951b1c394b7a27effb8eb6c9ee65dd77fcc4be7c20f76e3299a9e1e/langchain_aws-1.1.0.tar.gz", hash = "sha256:1e2f8570328eae4907c3cf7e900dc68d8034ddc865d9dc96823c9f9d8cccb901", size = 393899, upload-time = "2025-11-24T14:35:24.216Z" }
 wheels = [
@@ -1278,17 +1326,43 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
+version = "0.3.83"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "jsonpatch", marker = "python_full_version >= '3.12'" },
+    { name = "langsmith", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "uuid-utils", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a4/24f2d787bfcf56e5990924cacefe6f6e7971a3629f97c8162fc7a2a3d851/langchain_core-0.3.83.tar.gz", hash = "sha256:a0a4c7b6ea1c446d3b432116f405dc2afa1fe7891c44140d3d5acca221909415", size = 597965, upload-time = "2026-01-13T01:19:23.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/db/d71b80d3bd6193812485acea4001cdf86cf95a44bbf942f7a240120ff762/langchain_core-0.3.83-py3-none-any.whl", hash = "sha256:8c92506f8b53fc1958b1c07447f58c5783eb8833dd3cb6dc75607c80891ab1ae", size = 458890, upload-time = "2026-01-13T01:19:21.748Z" },
+]
+
+[[package]]
+name = "langchain-core"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "jsonpatch" },
-    { name = "langsmith" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "uuid-utils" },
+    { name = "jsonpatch", marker = "python_full_version < '3.12'" },
+    { name = "langsmith", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "pydantic", marker = "python_full_version < '3.12'" },
+    { name = "pyyaml", marker = "python_full_version < '3.12'" },
+    { name = "tenacity", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "uuid-utils", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/9b/da155eee3a21ecec2e1d6b78ca5fd2ee1936dcd36b0bf0b70d94b5ac6fce/langchain_core-1.1.1.tar.gz", hash = "sha256:029877a34ac5dedefe9c5c36e3c1206e56fc4cac6025df933277451b6df177ad", size = 799487, upload-time = "2025-12-04T19:55:12.935Z" }
 wheels = [
@@ -1296,16 +1370,28 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-text-splitters"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core", version = "0.3.83", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
+]
+
+[[package]]
 name = "langgraph"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
-    { name = "langgraph-checkpoint" },
-    { name = "langgraph-prebuilt" },
-    { name = "langgraph-sdk" },
-    { name = "pydantic" },
-    { name = "xxhash" },
+    { name = "langchain-core", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "langgraph-checkpoint", marker = "python_full_version < '3.12'" },
+    { name = "langgraph-prebuilt", marker = "python_full_version < '3.12'" },
+    { name = "langgraph-sdk", marker = "python_full_version < '3.12'" },
+    { name = "pydantic", marker = "python_full_version < '3.12'" },
+    { name = "xxhash", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/3c/af87902d300c1f467165558c8966d8b1e1f896dace271d3f35a410a5c26a/langgraph-1.0.4.tar.gz", hash = "sha256:86d08e25d7244340f59c5200fa69fdd11066aa999b3164b531e2a20036fac156", size = 484397, upload-time = "2025-11-25T20:31:48.608Z" }
 wheels = [
@@ -1317,8 +1403,8 @@ name = "langgraph-checkpoint"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
-    { name = "ormsgpack" },
+    { name = "langchain-core", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ormsgpack", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/07/2b1c042fa87d40cf2db5ca27dc4e8dd86f9a0436a10aa4361a8982718ae7/langgraph_checkpoint-3.0.1.tar.gz", hash = "sha256:59222f875f85186a22c494aedc65c4e985a3df27e696e5016ba0b98a5ed2cee0", size = 137785, upload-time = "2025-11-04T21:55:47.774Z" }
 wheels = [
@@ -1330,8 +1416,8 @@ name = "langgraph-prebuilt"
 version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
-    { name = "langgraph-checkpoint" },
+    { name = "langchain-core", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "langgraph-checkpoint", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/f9/54f8891b32159e4542236817aea2ee83de0de18bce28e9bdba08c7f93001/langgraph_prebuilt-1.0.5.tar.gz", hash = "sha256:85802675ad778cc7240fd02d47db1e0b59c0c86d8369447d77ce47623845db2d", size = 144453, upload-time = "2025-11-20T16:47:39.23Z" }
 wheels = [
@@ -1343,8 +1429,8 @@ name = "langgraph-sdk"
 version = "0.2.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "orjson" },
+    { name = "httpx", marker = "python_full_version < '3.12'" },
+    { name = "orjson", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/7e/76e02b0242ce184fb9e43a867509aa024f6aebaea9695f53bff30714f0d0/langgraph_sdk-0.2.12.tar.gz", hash = "sha256:7776a95af1e2b084806ad815655fe6f287ead082cae629c106aed72d6e9dce29", size = 124683, upload-time = "2025-12-02T15:47:32.891Z" }
 wheels = [
@@ -1538,152 +1624,34 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.2.6"
+version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
-    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
-    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
-    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
-    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
-    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
-    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
-    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
-    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
-    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
-    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
-]
-
-[[package]]
-name = "numpy"
-version = "2.3.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/65/21b3bc86aac7b8f2862db1e808f1ea22b028e30a225a34a5ede9bf8678f2/numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0", size = 20584950, upload-time = "2025-11-16T22:52:42.067Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/77/84dd1d2e34d7e2792a236ba180b5e8fcc1e3e414e761ce0253f63d7f572e/numpy-2.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de5672f4a7b200c15a4127042170a694d4df43c992948f5e1af57f0174beed10", size = 17034641, upload-time = "2025-11-16T22:49:19.336Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ea/25e26fa5837106cde46ae7d0b667e20f69cbbc0efd64cba8221411ab26ae/numpy-2.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acfd89508504a19ed06ef963ad544ec6664518c863436306153e13e94605c218", size = 12528324, upload-time = "2025-11-16T22:49:22.582Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/1a/e85f0eea4cf03d6a0228f5c0256b53f2df4bc794706e7df019fc622e47f1/numpy-2.3.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ffe22d2b05504f786c867c8395de703937f934272eb67586817b46188b4ded6d", size = 5356872, upload-time = "2025-11-16T22:49:25.408Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/bb/35ef04afd567f4c989c2060cde39211e4ac5357155c1833bcd1166055c61/numpy-2.3.5-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:872a5cf366aec6bb1147336480fef14c9164b154aeb6542327de4970282cd2f5", size = 6893148, upload-time = "2025-11-16T22:49:27.549Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/2b/05bbeb06e2dff5eab512dfc678b1cc5ee94d8ac5956a0885c64b6b26252b/numpy-2.3.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3095bdb8dd297e5920b010e96134ed91d852d81d490e787beca7e35ae1d89cf7", size = 14557282, upload-time = "2025-11-16T22:49:30.964Z" },
-    { url = "https://files.pythonhosted.org/packages/65/fb/2b23769462b34398d9326081fad5655198fcf18966fcb1f1e49db44fbf31/numpy-2.3.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cba086a43d54ca804ce711b2a940b16e452807acebe7852ff327f1ecd49b0d4", size = 16897903, upload-time = "2025-11-16T22:49:34.191Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/14/085f4cf05fc3f1e8aa95e85404e984ffca9b2275a5dc2b1aae18a67538b8/numpy-2.3.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6cf9b429b21df6b99f4dee7a1218b8b7ffbbe7df8764dc0bd60ce8a0708fed1e", size = 16341672, upload-time = "2025-11-16T22:49:37.2Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/3b/1f73994904142b2aa290449b3bb99772477b5fd94d787093e4f24f5af763/numpy-2.3.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:396084a36abdb603546b119d96528c2f6263921c50df3c8fd7cb28873a237748", size = 18838896, upload-time = "2025-11-16T22:49:39.727Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/b9/cf6649b2124f288309ffc353070792caf42ad69047dcc60da85ee85fea58/numpy-2.3.5-cp311-cp311-win32.whl", hash = "sha256:b0c7088a73aef3d687c4deef8452a3ac7c1be4e29ed8bf3b366c8111128ac60c", size = 6563608, upload-time = "2025-11-16T22:49:42.079Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/44/9fe81ae1dcc29c531843852e2874080dc441338574ccc4306b39e2ff6e59/numpy-2.3.5-cp311-cp311-win_amd64.whl", hash = "sha256:a414504bef8945eae5f2d7cb7be2d4af77c5d1cb5e20b296c2c25b61dff2900c", size = 13078442, upload-time = "2025-11-16T22:49:43.99Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a7/f99a41553d2da82a20a2f22e93c94f928e4490bb447c9ff3c4ff230581d3/numpy-2.3.5-cp311-cp311-win_arm64.whl", hash = "sha256:0cd00b7b36e35398fa2d16af7b907b65304ef8bb4817a550e06e5012929830fa", size = 10458555, upload-time = "2025-11-16T22:49:47.092Z" },
-    { url = "https://files.pythonhosted.org/packages/44/37/e669fe6cbb2b96c62f6bbedc6a81c0f3b7362f6a59230b23caa673a85721/numpy-2.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:74ae7b798248fe62021dbf3c914245ad45d1a6b0cb4a29ecb4b31d0bfbc4cc3e", size = 16733873, upload-time = "2025-11-16T22:49:49.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/65/df0db6c097892c9380851ab9e44b52d4f7ba576b833996e0080181c0c439/numpy-2.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ee3888d9ff7c14604052b2ca5535a30216aa0a58e948cdd3eeb8d3415f638769", size = 12259838, upload-time = "2025-11-16T22:49:52.863Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e1/1ee06e70eb2136797abe847d386e7c0e830b67ad1d43f364dd04fa50d338/numpy-2.3.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:612a95a17655e213502f60cfb9bf9408efdc9eb1d5f50535cc6eb365d11b42b5", size = 5088378, upload-time = "2025-11-16T22:49:55.055Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/9c/1ca85fb86708724275103b81ec4cf1ac1d08f465368acfc8da7ab545bdae/numpy-2.3.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:3101e5177d114a593d79dd79658650fe28b5a0d8abeb8ce6f437c0e6df5be1a4", size = 6628559, upload-time = "2025-11-16T22:49:57.371Z" },
-    { url = "https://files.pythonhosted.org/packages/74/78/fcd41e5a0ce4f3f7b003da85825acddae6d7ecb60cf25194741b036ca7d6/numpy-2.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b973c57ff8e184109db042c842423ff4f60446239bd585a5131cc47f06f789d", size = 14250702, upload-time = "2025-11-16T22:49:59.632Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/23/2a1b231b8ff672b4c450dac27164a8b2ca7d9b7144f9c02d2396518352eb/numpy-2.3.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d8163f43acde9a73c2a33605353a4f1bc4798745a8b1d73183b28e5b435ae28", size = 16606086, upload-time = "2025-11-16T22:50:02.127Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c5/5ad26fbfbe2012e190cc7d5003e4d874b88bb18861d0829edc140a713021/numpy-2.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:51c1e14eb1e154ebd80e860722f9e6ed6ec89714ad2db2d3aa33c31d7c12179b", size = 16025985, upload-time = "2025-11-16T22:50:04.536Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/fa/dd48e225c46c819288148d9d060b047fd2a6fb1eb37eae25112ee4cb4453/numpy-2.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b46b4ec24f7293f23adcd2d146960559aaf8020213de8ad1909dba6c013bf89c", size = 18542976, upload-time = "2025-11-16T22:50:07.557Z" },
-    { url = "https://files.pythonhosted.org/packages/05/79/ccbd23a75862d95af03d28b5c6901a1b7da4803181513d52f3b86ed9446e/numpy-2.3.5-cp312-cp312-win32.whl", hash = "sha256:3997b5b3c9a771e157f9aae01dd579ee35ad7109be18db0e85dbdbe1de06e952", size = 6285274, upload-time = "2025-11-16T22:50:10.746Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/57/8aeaf160312f7f489dea47ab61e430b5cb051f59a98ae68b7133ce8fa06a/numpy-2.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:86945f2ee6d10cdfd67bcb4069c1662dd711f7e2a4343db5cecec06b87cf31aa", size = 12782922, upload-time = "2025-11-16T22:50:12.811Z" },
-    { url = "https://files.pythonhosted.org/packages/78/a6/aae5cc2ca78c45e64b9ef22f089141d661516856cf7c8a54ba434576900d/numpy-2.3.5-cp312-cp312-win_arm64.whl", hash = "sha256:f28620fe26bee16243be2b7b874da327312240a7cdc38b769a697578d2100013", size = 10194667, upload-time = "2025-11-16T22:50:16.16Z" },
-    { url = "https://files.pythonhosted.org/packages/db/69/9cde09f36da4b5a505341180a3f2e6fadc352fd4d2b7096ce9778db83f1a/numpy-2.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d0f23b44f57077c1ede8c5f26b30f706498b4862d3ff0a7298b8411dd2f043ff", size = 16728251, upload-time = "2025-11-16T22:50:19.013Z" },
-    { url = "https://files.pythonhosted.org/packages/79/fb/f505c95ceddd7027347b067689db71ca80bd5ecc926f913f1a23e65cf09b/numpy-2.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa5bc7c5d59d831d9773d1170acac7893ce3a5e130540605770ade83280e7188", size = 12254652, upload-time = "2025-11-16T22:50:21.487Z" },
-    { url = "https://files.pythonhosted.org/packages/78/da/8c7738060ca9c31b30e9301ee0cf6c5ffdbf889d9593285a1cead337f9a5/numpy-2.3.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccc933afd4d20aad3c00bcef049cb40049f7f196e0397f1109dba6fed63267b0", size = 5083172, upload-time = "2025-11-16T22:50:24.562Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/b4/ee5bb2537fb9430fd2ef30a616c3672b991a4129bb1c7dcc42aa0abbe5d7/numpy-2.3.5-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afaffc4393205524af9dfa400fa250143a6c3bc646c08c9f5e25a9f4b4d6a903", size = 6622990, upload-time = "2025-11-16T22:50:26.47Z" },
-    { url = "https://files.pythonhosted.org/packages/95/03/dc0723a013c7d7c19de5ef29e932c3081df1c14ba582b8b86b5de9db7f0f/numpy-2.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c75442b2209b8470d6d5d8b1c25714270686f14c749028d2199c54e29f20b4d", size = 14248902, upload-time = "2025-11-16T22:50:28.861Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/10/ca162f45a102738958dcec8023062dad0cbc17d1ab99d68c4e4a6c45fb2b/numpy-2.3.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e06aa0af8c0f05104d56450d6093ee639e15f24ecf62d417329d06e522e017", size = 16597430, upload-time = "2025-11-16T22:50:31.56Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/51/c1e29be863588db58175175f057286900b4b3327a1351e706d5e0f8dd679/numpy-2.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ed89927b86296067b4f81f108a2271d8926467a8868e554eaf370fc27fa3ccaf", size = 16024551, upload-time = "2025-11-16T22:50:34.242Z" },
-    { url = "https://files.pythonhosted.org/packages/83/68/8236589d4dbb87253d28259d04d9b814ec0ecce7cb1c7fed29729f4c3a78/numpy-2.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51c55fe3451421f3a6ef9a9c1439e82101c57a2c9eab9feb196a62b1a10b58ce", size = 18533275, upload-time = "2025-11-16T22:50:37.651Z" },
-    { url = "https://files.pythonhosted.org/packages/40/56/2932d75b6f13465239e3b7b7e511be27f1b8161ca2510854f0b6e521c395/numpy-2.3.5-cp313-cp313-win32.whl", hash = "sha256:1978155dd49972084bd6ef388d66ab70f0c323ddee6f693d539376498720fb7e", size = 6277637, upload-time = "2025-11-16T22:50:40.11Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/88/e2eaa6cffb115b85ed7c7c87775cb8bcf0816816bc98ca8dbfa2ee33fe6e/numpy-2.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:00dc4e846108a382c5869e77c6ed514394bdeb3403461d25a829711041217d5b", size = 12779090, upload-time = "2025-11-16T22:50:42.503Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/88/3f41e13a44ebd4034ee17baa384acac29ba6a4fcc2aca95f6f08ca0447d1/numpy-2.3.5-cp313-cp313-win_arm64.whl", hash = "sha256:0472f11f6ec23a74a906a00b48a4dcf3849209696dff7c189714511268d103ae", size = 10194710, upload-time = "2025-11-16T22:50:44.971Z" },
-    { url = "https://files.pythonhosted.org/packages/13/cb/71744144e13389d577f867f745b7df2d8489463654a918eea2eeb166dfc9/numpy-2.3.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:414802f3b97f3c1eef41e530aaba3b3c1620649871d8cb38c6eaff034c2e16bd", size = 16827292, upload-time = "2025-11-16T22:50:47.715Z" },
-    { url = "https://files.pythonhosted.org/packages/71/80/ba9dc6f2a4398e7f42b708a7fdc841bb638d353be255655498edbf9a15a8/numpy-2.3.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5ee6609ac3604fa7780e30a03e5e241a7956f8e2fcfe547d51e3afa5247ac47f", size = 12378897, upload-time = "2025-11-16T22:50:51.327Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/6d/db2151b9f64264bcceccd51741aa39b50150de9b602d98ecfe7e0c4bff39/numpy-2.3.5-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:86d835afea1eaa143012a2d7a3f45a3adce2d7adc8b4961f0b362214d800846a", size = 5207391, upload-time = "2025-11-16T22:50:54.542Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ae/429bacace5ccad48a14c4ae5332f6aa8ab9f69524193511d60ccdfdc65fa/numpy-2.3.5-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:30bc11310e8153ca664b14c5f1b73e94bd0503681fcf136a163de856f3a50139", size = 6721275, upload-time = "2025-11-16T22:50:56.794Z" },
-    { url = "https://files.pythonhosted.org/packages/74/5b/1919abf32d8722646a38cd527bc3771eb229a32724ee6ba340ead9b92249/numpy-2.3.5-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1062fde1dcf469571705945b0f221b73928f34a20c904ffb45db101907c3454e", size = 14306855, upload-time = "2025-11-16T22:50:59.208Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/87/6831980559434973bebc30cd9c1f21e541a0f2b0c280d43d3afd909b66d0/numpy-2.3.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce581db493ea1a96c0556360ede6607496e8bf9b3a8efa66e06477267bc831e9", size = 16657359, upload-time = "2025-11-16T22:51:01.991Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/91/c797f544491ee99fd00495f12ebb7802c440c1915811d72ac5b4479a3356/numpy-2.3.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:cc8920d2ec5fa99875b670bb86ddeb21e295cb07aa331810d9e486e0b969d946", size = 16093374, upload-time = "2025-11-16T22:51:05.291Z" },
-    { url = "https://files.pythonhosted.org/packages/74/a6/54da03253afcbe7a72785ec4da9c69fb7a17710141ff9ac5fcb2e32dbe64/numpy-2.3.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9ee2197ef8c4f0dfe405d835f3b6a14f5fee7782b5de51ba06fb65fc9b36e9f1", size = 18594587, upload-time = "2025-11-16T22:51:08.585Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e9/aff53abbdd41b0ecca94285f325aff42357c6b5abc482a3fcb4994290b18/numpy-2.3.5-cp313-cp313t-win32.whl", hash = "sha256:70b37199913c1bd300ff6e2693316c6f869c7ee16378faf10e4f5e3275b299c3", size = 6405940, upload-time = "2025-11-16T22:51:11.541Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/81/50613fec9d4de5480de18d4f8ef59ad7e344d497edbef3cfd80f24f98461/numpy-2.3.5-cp313-cp313t-win_amd64.whl", hash = "sha256:b501b5fa195cc9e24fe102f21ec0a44dffc231d2af79950b451e0d99cea02234", size = 12920341, upload-time = "2025-11-16T22:51:14.312Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ab/08fd63b9a74303947f34f0bd7c5903b9c5532c2d287bead5bdf4c556c486/numpy-2.3.5-cp313-cp313t-win_arm64.whl", hash = "sha256:a80afd79f45f3c4a7d341f13acbe058d1ca8ac017c165d3fa0d3de6bc1a079d7", size = 10262507, upload-time = "2025-11-16T22:51:16.846Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/97/1a914559c19e32d6b2e233cf9a6a114e67c856d35b1d6babca571a3e880f/numpy-2.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:bf06bc2af43fa8d32d30fae16ad965663e966b1a3202ed407b84c989c3221e82", size = 16735706, upload-time = "2025-11-16T22:51:19.558Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d4/51233b1c1b13ecd796311216ae417796b88b0616cfd8a33ae4536330748a/numpy-2.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:052e8c42e0c49d2575621c158934920524f6c5da05a1d3b9bab5d8e259e045f0", size = 12264507, upload-time = "2025-11-16T22:51:22.492Z" },
-    { url = "https://files.pythonhosted.org/packages/45/98/2fe46c5c2675b8306d0b4a3ec3494273e93e1226a490f766e84298576956/numpy-2.3.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:1ed1ec893cff7040a02c8aa1c8611b94d395590d553f6b53629a4461dc7f7b63", size = 5093049, upload-time = "2025-11-16T22:51:25.171Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/0e/0698378989bb0ac5f1660c81c78ab1fe5476c1a521ca9ee9d0710ce54099/numpy-2.3.5-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:2dcd0808a421a482a080f89859a18beb0b3d1e905b81e617a188bd80422d62e9", size = 6626603, upload-time = "2025-11-16T22:51:27Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/a6/9ca0eecc489640615642a6cbc0ca9e10df70df38c4d43f5a928ff18d8827/numpy-2.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727fd05b57df37dc0bcf1a27767a3d9a78cbbc92822445f32cc3436ba797337b", size = 14262696, upload-time = "2025-11-16T22:51:29.402Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/f6/07ec185b90ec9d7217a00eeeed7383b73d7e709dae2a9a021b051542a708/numpy-2.3.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fffe29a1ef00883599d1dc2c51aa2e5d80afe49523c261a74933df395c15c520", size = 16597350, upload-time = "2025-11-16T22:51:32.167Z" },
-    { url = "https://files.pythonhosted.org/packages/75/37/164071d1dde6a1a84c9b8e5b414fa127981bad47adf3a6b7e23917e52190/numpy-2.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8f7f0e05112916223d3f438f293abf0727e1181b5983f413dfa2fefc4098245c", size = 16040190, upload-time = "2025-11-16T22:51:35.403Z" },
-    { url = "https://files.pythonhosted.org/packages/08/3c/f18b82a406b04859eb026d204e4e1773eb41c5be58410f41ffa511d114ae/numpy-2.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2e2eb32ddb9ccb817d620ac1d8dae7c3f641c1e5f55f531a33e8ab97960a75b8", size = 18536749, upload-time = "2025-11-16T22:51:39.698Z" },
-    { url = "https://files.pythonhosted.org/packages/40/79/f82f572bf44cf0023a2fe8588768e23e1592585020d638999f15158609e1/numpy-2.3.5-cp314-cp314-win32.whl", hash = "sha256:66f85ce62c70b843bab1fb14a05d5737741e74e28c7b8b5a064de10142fad248", size = 6335432, upload-time = "2025-11-16T22:51:42.476Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/2e/235b4d96619931192c91660805e5e49242389742a7a82c27665021db690c/numpy-2.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:e6a0bc88393d65807d751a614207b7129a310ca4fe76a74e5c7da5fa5671417e", size = 12919388, upload-time = "2025-11-16T22:51:45.275Z" },
-    { url = "https://files.pythonhosted.org/packages/07/2b/29fd75ce45d22a39c61aad74f3d718e7ab67ccf839ca8b60866054eb15f8/numpy-2.3.5-cp314-cp314-win_arm64.whl", hash = "sha256:aeffcab3d4b43712bb7a60b65f6044d444e75e563ff6180af8f98dd4b905dfd2", size = 10476651, upload-time = "2025-11-16T22:51:47.749Z" },
-    { url = "https://files.pythonhosted.org/packages/17/e1/f6a721234ebd4d87084cfa68d081bcba2f5cfe1974f7de4e0e8b9b2a2ba1/numpy-2.3.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17531366a2e3a9e30762c000f2c43a9aaa05728712e25c11ce1dbe700c53ad41", size = 16834503, upload-time = "2025-11-16T22:51:50.443Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/1c/baf7ffdc3af9c356e1c135e57ab7cf8d247931b9554f55c467efe2c69eff/numpy-2.3.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d21644de1b609825ede2f48be98dfde4656aefc713654eeee280e37cadc4e0ad", size = 12381612, upload-time = "2025-11-16T22:51:53.609Z" },
-    { url = "https://files.pythonhosted.org/packages/74/91/f7f0295151407ddc9ba34e699013c32c3c91944f9b35fcf9281163dc1468/numpy-2.3.5-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c804e3a5aba5460c73955c955bdbd5c08c354954e9270a2c1565f62e866bdc39", size = 5210042, upload-time = "2025-11-16T22:51:56.213Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/3b/78aebf345104ec50dd50a4d06ddeb46a9ff5261c33bcc58b1c4f12f85ec2/numpy-2.3.5-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:cc0a57f895b96ec78969c34f682c602bf8da1a0270b09bc65673df2e7638ec20", size = 6724502, upload-time = "2025-11-16T22:51:58.584Z" },
-    { url = "https://files.pythonhosted.org/packages/02/c6/7c34b528740512e57ef1b7c8337ab0b4f0bddf34c723b8996c675bc2bc91/numpy-2.3.5-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:900218e456384ea676e24ea6a0417f030a3b07306d29d7ad843957b40a9d8d52", size = 14308962, upload-time = "2025-11-16T22:52:01.698Z" },
-    { url = "https://files.pythonhosted.org/packages/80/35/09d433c5262bc32d725bafc619e095b6a6651caf94027a03da624146f655/numpy-2.3.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09a1bea522b25109bf8e6f3027bd810f7c1085c64a0c7ce050c1676ad0ba010b", size = 16655054, upload-time = "2025-11-16T22:52:04.267Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ab/6a7b259703c09a88804fa2430b43d6457b692378f6b74b356155283566ac/numpy-2.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:04822c00b5fd0323c8166d66c701dc31b7fbd252c100acd708c48f763968d6a3", size = 16091613, upload-time = "2025-11-16T22:52:08.651Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/88/330da2071e8771e60d1038166ff9d73f29da37b01ec3eb43cb1427464e10/numpy-2.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d6889ec4ec662a1a37eb4b4fb26b6100841804dac55bd9df579e326cdc146227", size = 18591147, upload-time = "2025-11-16T22:52:11.453Z" },
-    { url = "https://files.pythonhosted.org/packages/51/41/851c4b4082402d9ea860c3626db5d5df47164a712cb23b54be028b184c1c/numpy-2.3.5-cp314-cp314t-win32.whl", hash = "sha256:93eebbcf1aafdf7e2ddd44c2923e2672e1010bddc014138b229e49725b4d6be5", size = 6479806, upload-time = "2025-11-16T22:52:14.641Z" },
-    { url = "https://files.pythonhosted.org/packages/90/30/d48bde1dfd93332fa557cff1972fbc039e055a52021fbef4c2c4b1eefd17/numpy-2.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c8a9958e88b65c3b27e22ca2a076311636850b612d6bbfb76e8d156aacde2aaf", size = 13105760, upload-time = "2025-11-16T22:52:17.975Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/fd/4b5eb0b3e888d86aee4d198c23acec7d214baaf17ea93c1adec94c9518b9/numpy-2.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:6203fdf9f3dc5bdaed7319ad8698e685c7a3be10819f41d32a0723e611733b42", size = 10545459, upload-time = "2025-11-16T22:52:20.55Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/65/f9dea8e109371ade9c782b4e4756a82edf9d3366bca495d84d79859a0b79/numpy-2.3.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f0963b55cdd70fad460fa4c1341f12f976bb26cb66021a5580329bd498988310", size = 16910689, upload-time = "2025-11-16T22:52:23.247Z" },
-    { url = "https://files.pythonhosted.org/packages/00/4f/edb00032a8fb92ec0a679d3830368355da91a69cab6f3e9c21b64d0bb986/numpy-2.3.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f4255143f5160d0de972d28c8f9665d882b5f61309d8362fdd3e103cf7bf010c", size = 12457053, upload-time = "2025-11-16T22:52:26.367Z" },
-    { url = "https://files.pythonhosted.org/packages/16/a4/e8a53b5abd500a63836a29ebe145fc1ab1f2eefe1cfe59276020373ae0aa/numpy-2.3.5-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:a4b9159734b326535f4dd01d947f919c6eefd2d9827466a696c44ced82dfbc18", size = 5285635, upload-time = "2025-11-16T22:52:29.266Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/2f/37eeb9014d9c8b3e9c55bc599c68263ca44fdbc12a93e45a21d1d56df737/numpy-2.3.5-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:2feae0d2c91d46e59fcd62784a3a83b3fb677fead592ce51b5a6fbb4f95965ff", size = 6801770, upload-time = "2025-11-16T22:52:31.421Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/e4/68d2f474df2cb671b2b6c2986a02e520671295647dad82484cde80ca427b/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffac52f28a7849ad7576293c0cb7b9f08304e8f7d738a8cb8a90ec4c55a998eb", size = 14391768, upload-time = "2025-11-16T22:52:33.593Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/50/94ccd8a2b141cb50651fddd4f6a48874acb3c91c8f0842b08a6afc4b0b21/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63c0e9e7eea69588479ebf4a8a270d5ac22763cc5854e9a7eae952a3908103f7", size = 16729263, upload-time = "2025-11-16T22:52:36.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ee/346fa473e666fe14c52fcdd19ec2424157290a032d4c41f98127bfb31ac7/numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425", size = 12967213, upload-time = "2025-11-16T22:52:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0", size = 20631468, upload-time = "2024-02-05T23:48:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a", size = 13966411, upload-time = "2024-02-05T23:48:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4", size = 14219016, upload-time = "2024-02-05T23:48:54.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f", size = 18240889, upload-time = "2024-02-05T23:49:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a", size = 13876746, upload-time = "2024-02-05T23:49:51.983Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2", size = 18078620, upload-time = "2024-02-05T23:50:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07", size = 5972659, upload-time = "2024-02-05T23:50:35.834Z" },
+    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5", size = 15808905, upload-time = "2024-02-05T23:51:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554, upload-time = "2024-02-05T23:51:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127, upload-time = "2024-02-05T23:52:15.314Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994, upload-time = "2024-02-05T23:52:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005, upload-time = "2024-02-05T23:53:15.637Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297, upload-time = "2024-02-05T23:53:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
 ]
 
 [[package]]
@@ -1836,8 +1804,7 @@ name = "pandas"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -2589,15 +2556,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
-]
-
-[[package]]
-name = "semver"
-version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds functionality to the upgrader panel app to show side-by-side comparisons of the pre/post upgraded metadata. I had already demonstrated proof of concept for this in a flask app. Here are three examples in my prototype flask app (visible only on prem or on the VPN):

1. An asset that properly upgrades: http://10.128.142.221:8080/upgrader/?asset_id=single-plane-ophys_705363_2024-01-10_15-46-42
2. An asset with one failure (in session): http://10.128.142.221:8080/upgrader/?asset_id=behavior_689727_2024-02-07_15-01-36
3. An asset with two failures (session and procedures): http://10.128.142.221:8080/upgrader/?asset_id=behavior_746346_2025-03-12_17-21-50

To test the updated panel app with this new functionality:
* check out this branch `git checkout add_detailed_upgrade_output_to_app`
* run the panel app locally: `uv run panel serve src/aind_metadata_viz/upgrade.py --show --autoreload`
* Visit the app in your browser: `http://localhost:5006/upgrade`

Here are screenshots of the panel app for these same three assets:
<img width="1800" height="1002" alt="image" src="https://github.com/user-attachments/assets/39d05763-683d-4bc2-922a-1c292b713b3c" />

<img width="1800" height="1003" alt="image" src="https://github.com/user-attachments/assets/8230e4df-b80a-4c1d-830b-64c572d9fc79" />

<img width="1800" height="1001" alt="image" src="https://github.com/user-attachments/assets/eac4b0a6-3b88-49de-bb97-57fee8434b7a" />
